### PR TITLE
CI-only: mypy uses the first assignment as type: Declare types on it

### DIFF
--- a/.github/instructions/type-comments.instructions.md
+++ b/.github/instructions/type-comments.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "xen-bugtool"
+---
+# Type hints only in type comments
+
+As we still support Python 2.7, we cannot use Python 3 type annotations.
+As an alternative, we use type comments.
+As type comments are not code, we shall use modern type hints in them.
+
+## Details: Inside type comments, use modern type hints
+
+We only use type checkers that understand modern type hints in type comments.
+
+This includes:
+
+- Type1 | Type2 union types
+- list[Type] instead of List[Type]
+- dict[KeyType, ValueType] instead of Dict[KeyType, ValueType]
+- etc.
+
+Type comments are not code, and only type checkers see them.

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1830,10 +1830,9 @@ def load_plugins(just_capabilities = False):
                     recursive = getBoolAttr(el, 'recursive')
                     dir_list(dir, getText(el.childNodes).split(), recursive)
                 elif el.tagName == "directory":
-                    pattern = el.getAttribute("pattern")
-                    if pattern == '': pattern = None
+                    pattern = re.compile(el.getAttribute("pattern"))
                     negate = getBoolAttr(el, 'negate')
-                    tree_output(dir, getText(el.childNodes), pattern and re.compile(pattern) or None, negate)
+                    tree_output(dir, getText(el.childNodes), pattern, negate)
                 elif el.tagName == "command":
                     label = el.getAttribute("label")
                     if label == '': label = None
@@ -2142,7 +2141,7 @@ def matches(f, pattern, negate):
     if negate:
         return not matches(f, pattern, False)
     else:
-        return pattern is None or pattern.match(f)
+        return not pattern or pattern.match(f)
 
 
 def size_of(f, pattern, negate):

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -558,13 +558,14 @@ def output_ts(x):
     output("[%s]  %s" % (time.strftime("%x %X %Z"), x))
 
 def cmd_output(cap, args, label = None, filter = None):
+    """If the cap shall be collected, add the specification to run the command"""
     if cap in entries:
-        if not label:
-            if isinstance(args, list):
-                a = [aa for aa in args]
+        if not label:  # The default label is the command with its arguments
+            if isinstance(args, list):  # The command is a list[str], so join it
+                a = list(args)
                 a[0] = os.path.basename(a[0])
                 label = ' '.join(a)
-            else:
+            else:  # The command is a non-empty string, so use it as is
                 label = args
         data[label] = {'cap': cap, 'cmd_args': args, 'filter': filter}
 
@@ -1835,7 +1836,6 @@ def load_plugins(just_capabilities = False):
                     tree_output(dir, getText(el.childNodes), pattern, negate)
                 elif el.tagName == "command":
                     label = el.getAttribute("label")
-                    if label == '': label = None
                     cmd_output(dir, getText(el.childNodes), label)
 
 def removeNoError(filename):


### PR DESCRIPTION
CI-only: mypy uses the first assignment as type: Declare types on it

## Summary by Sourcery

Add explicit type annotations to initial assignments to satisfy mypy's type inference rules

Enhancements:
- Declare types on first assignments to ensure correct mypy typing

CI:
- Update code annotations to fix CI mypy errors