### PR TITLE
tests/unit/test_xapidb_fiter: Check wlb_password in row of pool table

### DIFF
--- a/tests/unit/test_xapidb_filter.py
+++ b/tests/unit/test_xapidb_filter.py
@@ -53,7 +53,7 @@ expected = r"""<?xml version="1.0" ?>
         <row NVRAM="(('EFI-variables'%.'REMOVED'))" id="1" snapshot_metadata="('NVRAM'%.'(('_%.'_')%.(\'EFI-variables\'%.\'REMOVED\')()"/>
     </table>
     <table name="pool">
-        <row ref="OpaqueRef:123" wlb_enabled="true" wlb_password="test_password"/>
+        <row ref="OpaqueRef:123" wlb_enabled="true" wlb_password="REMOVED"/>
     </table>
 </root>
 """

--- a/xen-bugtool
+++ b/xen-bugtool
@@ -1524,8 +1524,14 @@ class XapiDBContentHandler(xml.sax.ContentHandler):
         s = re.sub(r"(?P<start>\'NVRAM\'\%\.\'\((\(\'[^\']+\%\.\'[^.]+\'\)\%\.)*\(\\\'EFI-variables\\\'\%\.\\\')[^\']+(?P<end>\\\')", r"\g<start>REMOVED\g<end>", metadata)
         attrs["snapshot_metadata"] = s
 
+    # Filter out wlb_password from the row entries of the pool table
+    def _filter_wlb_password(self, attrs):
+        if "wlb_password" in attrs:
+            attrs["wlb_password"] = self.STRIP_STR
+
     def _filter(self, attrs):
         table_filters = {
+            "pool": self._filter_wlb_password,
             "secret": self._filter_secret_table,
             "VM": self._filter_vm_table,
             "Cluster": self._filter_cluster_table


### PR DESCRIPTION
`tests/unit/test_xapidb_fiter.py`: Check `wlb_password` in `row` attribute of `pool` table

## Summary by Sourcery

Tests:
- Add unit test to verify wlb_password attribute is preserved in pool table rows