### PR TITLE
`docs`: Extend the developer hints on pytest in `README-pytest.md`

### DIFF
--- a/README-pytest.md
+++ b/README-pytest.md
@@ -79,8 +79,7 @@ test, as some test cases check the output:
 - `pytest --capture=no` disables capturing the output of the code under test.
   But this may not work well for test cases that assert the output.
 
-Instead, add new, dedicated logs to the test or the code under test
-or even the test case.
+Instead, add new, dedicated logs to the test case or the code under test.
 
 You can do this by instrumenting the code at the desired location using `logging`:
 


### PR DESCRIPTION
`docs`: Extend the developer hints on pytest in `README-pytest.md`

## Summary by Sourcery

Extend README-pytest.md with additional developer hints for pytest usage

Documentation:
- Add guidance on using pytest -s to disable output capture
- Include code examples for adding logging warnings for debugging
- Include instructions for setting breakpoints with pdb.set_trace