### PR TITLE
Add tests/unit/test_cmd_output.py: Add new test cases for cmd_output()

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,47 @@
+# MD001/heading-increment:
+# Heading levels do not need to increment by one level at a time
+MD001: false
+
+# MD012/no-multiple-blanks:
+# Two consecutive blank lines are allowed
+MD012:
+  maximum: 2
+
+# MD013/line-length:
+# Set line length to 150 characters for now, until README.md is restructured
+MD013:
+   line_length: 100
+   code_block_line_length: 88
+
+# MD014/commands-show-output:
+# Dollar signs used before commands without showing output are permitted
+MD014: false
+
+# MD022/blanks-around-headings:
+# Headings do not need to be surrounded by blank lines for now
+MD022:
+  lines_above: 0
+  lines_below: 0
+
+# MD026/no-trailing-punctuation:
+# Some trailing punctuation in heading is allowed for now, most not.
+MD026:
+  # Punctuation characters
+  punctuation: ",;!。，；：！"
+
+# MD032/blanks-around-lists:
+# Lists do not need to be surrounded by blank lines for now
+MD032: false
+
+# MD033/no-inline-html:
+# Allow certain inline HTML elements
+MD033:
+  allowed_elements: [img, kbd]
+
+# MD034/no-bare-urls:
+# Bare URLs are allowed for now
+MD034: false
+
+# MD045/no-alt-text:
+# Images without alt text are allowed for now
+MD045: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,6 +191,14 @@ repos:
         additional_dependencies: [coverage]
 
 
+-    repo: https://github.com/igorshubovych/markdownlint-cli
+     rev: v0.45.0
+     hooks:
+     -  id: markdownlint
+        # The updated fixes for conftest-README.md are in PR #169
+        exclude: tests/unit/conftest-README.md
+
+
 -   repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.408
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -134,31 +134,23 @@ allow-any-import-level=XenAPI,xen.lowlevel.xc
 # --disable=W".
 
 # Common checks which need to be disabled for now and shall be fixed one by one:
-disable=anomalous-backslash-in-string,
+disable=broad-exception-caught,
         attribute-defined-outside-init,
-        bad-builtin,
         bare-except,
-        broad-except,
-        consider-iterating-dictionary,
         consider-using-dict-items,
         consider-using-f-string,
         consider-using-generator,
         consider-using-in,
-        consider-using-ternary,
         consider-using-tuple,
         consider-using-with,
-        else-if-used,
         fixme,
         global-statement,
         import-error,
         import-outside-toplevel,
         invalid-name,
-        invalid-name,
-        len-as-condition,
         missing-type-doc,  # better do typing than type in the param docstring
         no-else-break,
         no-else-return,
-        no-name-in-module,
         protected-access,
         redefined-builtin,
         redefined-outer-name,
@@ -175,8 +167,6 @@ disable=anomalous-backslash-in-string,
         wrong-import-order,
         # Py2 compat: Python2 requires calls to super() to have it's arguments:
         super-with-arguments,
-        # Py2 compat: As long as we try to use conditional imports for Py2+Py3:
-        ungrouped-imports,
         use-maxsplit-arg
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,6 @@
         "sourcery.sourcery",
         "streetsidesoftware.code-spell-checker",
         "timonwong.shellcheck",
-        "valentjn.vscode-ltex",
+        "ltex-plus.vscode-ltex-plus",
     ]
 }

--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -119,6 +119,7 @@ ifaces
 inet
 init
 initialisation
+Initialise
 initialised
 initiatorname
 inotify

--- a/README-Windows-WSL2.md
+++ b/README-Windows-WSL2.md
@@ -1,5 +1,5 @@
 
-## Recommendations for local Development on Windows and WSL2
+# Recommendations for local Development on Windows and WSL2
 
 ### Using Docker on WSL2/22.04
 

--- a/README-pytest.md
+++ b/README-pytest.md
@@ -148,43 +148,16 @@ See [doc/testing.md](doc/testing.md) for the different types of tests.
   Calls `xen-bugtool`'s `main()` to generate bug-reports using all output
   formats and verifies the output.
 
-## Discussion on the current state of testing of `xen-bugtool`
+## Tips on testing the status report tool using pytest and pyfakefs
 
-- Unit test cover the cases where we need to supply different input data.
-- Integration and E2E tests use files from
-[`tests/integration/dom0-template`](tests/integration/dom0-template) directly:
-  - We can start to add tests that copy these files into the virtual
-    [pyfakefs](https://pytest-pyfakefs.readthedocs.io/en/v3.7.2/usage.html)
-    file system to test using a virtual file system.
-  - It allows to vary the input data to test different kinds of input data.
-  - Six test cases of [python-libs](https://github.com/xenserver/python-libs)
-    use it very successfully.
+Tip: Use [pyfakefs](https://pytest-pyfakefs.readthedocs.io/en/v3.7.2/usage.html)
+to create a fake file system for test cases. Examples:
 
-- Currently, the End-to-End and integration tests provide most code coverage,
-  which we urgently needed to verify the correctness of the Python3 migrations.
-
-- Unit tests to ensure that the individual functions handle specific correctly
-  are needed still.
-
-
-## Suggested `pytest` plugins for development of test cases
-
-### pytest-pickled
-When updating existing tests or developing new code with new test coverage, we might want to
-ignore all other tests. This can be achieved with an exciting plugin called `pytest-picked`:
-`pytest --picked` will collect all test modules that were newly created or changed but not
-yet committed in a Git repository and run only them.
-
-### pytest-sugar
-`pytest-sugar` is a plugin that, once installed, automatically changes the format of the
-`pytest` standard output to include a graphical %-progress bar when running the test suite.
-
-### Installation of these pytest plugins
-For nicer diffs of dictionaries, arrays, and the like,
-use `pytest-clarity` or `pytest-icdiff`:
-
-```py
-pip install "pytest<7" pytest-picked pytest-sugar pytest-clarity # pytest-icdiff
-```
+- [tests/unit/test_file_output.py](tests/unit/test_file_output.py)
+  - Creates fake files to assert which files are requested for collection.
+  - Captures sys.stdout to assert the expected log messages.
+  - Captures the log file to assert the expected log messages in the file.
+- [tests/unit/test_dump_xapi_procs.py](tests/unit/test_dump_xapi_procs.py)
+  - Creates a fake /proc filesystem and asserts the expected data for collection.
 
 For more information to debug `pytest` test suites see: https://stribny.name/blog/pytest/

--- a/README-pytest.md
+++ b/README-pytest.md
@@ -31,13 +31,30 @@ The test environment contains two classes of test frameworks:
 
 ## Testing this project
 
-To run the tests using, simply run `pytest`.
+To install `pytest` with the dependencies for running the tests, you can use
+a Python `venv`/`virtualenv` or use `pipx`.
 
-The pytest.ini configures `pytest` to show you logs of failed tests.
+Many times, using `pipx` would be enough and can be easier to handle because
+you can inject the test dependencies into the environment of the `pytest`
+installation of `pipx`, and you do not have to activate a Python environment
+to run `pytest`. You only need to ensure that the `~/.local/bin/` is in your PATH.
 
-For development, do show also logs from passing tests, run `pytest -rA`
+```bash
+sudo apt purge pytest # The distribution pytests are outdated, don't use old tools
+sudo apt install pipx
+pipx ensurepath  # Ensures that `~/.local/bin/` is in your PATH, restart the shell
+pipx install pytest  # The new maintainers made big improvements in current pytest
+pipx inject pytest pyfakefs pytest-mock lxml mock defusedxml
+```
 
-In case a test fails on an asserting, use `pytest -vv` to get the full assert.
+The last command injects the dependencies into the `pytest` environment of `pipx`.
+
+To run all tests, simply run `pytest`.
+
+Hints:
+- `pytest.ini` configures `pytest` to show you logs of failed tests.
+- To also show logs of passing tests, use: `pytest -rA`
+- When test fails in an `assert`, use `pytest -vv` to get all assertion output.
 
 ### Introduction to `pytest`, `pytest.mark` and `pytest fixtures`:
 

--- a/README-python-install.md
+++ b/README-python-install.md
@@ -1,4 +1,4 @@
-## Local Python Development setup on Ubuntu 20.04 / 22.04
+# Local Python Development setup on Ubuntu 20.04 / 22.04
 
 For running the Unit tests and static analysis tools, use a relatively modern
 Linux VM. Possible are Fedora37+, but the documentation here focuses on
@@ -7,6 +7,7 @@ Ubuntu20.04 and 22.04 as they are the defaults of WSL and hosts:
 ```bash
 sudo apt update;sudo apt install software-properties-common python{2,3}
 ```
+
 Ubuntu no longer packages `python2-pip`, so you have to install `pip2`
 [this way](https://askubuntu.com/questions/1317353/how-can-i-find-an-older-version-of-pip-that-works-with-python-2-7):
 
@@ -21,7 +22,8 @@ echo 'PATH="~/.local/bin/pip:$PATH"' >>~/.bash_aliases
 . ~/.bash_aliases
 ```
 
-You can install specific Python verisons using this PPA:
+You can install specific Python versions using this PPA:
+
 ```bash
 sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo apt-get install -y python3.{8,11}{,-distutils}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ pip install radon
 # Clone python-libs, and host-installer copy perfmon from xen-api, then run:
 radon cc xen-bugtool host-installer/ perfmon xcp --total-average -nd --md
 ```
+
 ##### Output:
 
 | Filename | Name | Type | Start:End Line | Complexity | Classification |

--- a/README.md
+++ b/README.md
@@ -9,14 +9,29 @@ the development environment for `xen-bugtool`,
 a tool designed to assist with debugging XenServer issues.
 
 For more information, see these README files:
+
+Development practices and guidelines:
+- [doc/development.md](doc/development.md): Development guidelines and best practices
+- [doc/release.md](doc/release.md): Instructions for creating a new release
+
+Setting up the development environment:
 - [README-python-install.md](README-python-install.md) - Preparing your
   Development VM for running the test suite
-- [README-pytest.md](README-pytest.md) - Introduction on the recommended pytest suite for unit tests
-- [README-pytest-chroot.md](README-pytest-chroot.md) - Introduction on the `pytest-chroot` test suite
 - [README-Windows-WSL2.md](README-Windows-WSL2.md) - Windows and WSL2 setup tips
-- [doc/pre-commit.md](doc/pre-commmit.md):
-  Using `pre-commit` to run the test and static analysis checks locally
+
+Automated tests:
+- [doc/testing.md](doc/testing.md): Overview of the different types of tests
+- [doc/pre-commit.md](doc/pre-commit.md):
+  Using `pre-commit` to run tests and static analysis checks locally
 - [doc/coverage.md](doc/coverage.md): Introduction on **coverage** from `pytest`
+
+Documentation on pytest and its fixtures:
+- [README-pytest.md](README-pytest.md):
+  Introduction on the recommended pytest suite for unit tests
+- [README-pytest-chroot.md](README-pytest-chroot.md):
+  Introduction on the `pytest`-based integration test suite using namespaces
+- [tests/unit/conftest-README.md](tests/unit/conftest-README.md):
+  Introduction on the `pytest` fixtures defined in `tests/unit/conftest.py`
 
 ## Frequently asked Questions
 
@@ -71,7 +86,8 @@ or 15). Beyond these values, functions tend to be difficult to test and maintain
 and are thus good candidates for a redesign or refactoring.
 
 You should keep in mind that both metrics are independent of the number of lines
-of code in your function. If you have 100 consecutive statements with no branches (conditions, loops, etc.), you'll get a value of 1 for both of them.
+of code in your function. If you have 100 consecutive statements with no branches
+(conditions, loops, etc.), you'll get a value of 1 for both of them.
 
 #### Blind spots of complexity metrics
 ##### Consistent and easy to read Code style and formatting rules
@@ -105,49 +121,6 @@ pip install radon
 # Clone python-libs, and host-installer copy perfmon from xen-api, then run:
 radon cc xen-bugtool host-installer/ perfmon xcp --total-average -nd --md
 ```
-
-##### Output:
-
-| Filename | Name | Type | Start:End Line | Complexity | Classification |
-| -------- | ---- | ---- | -------------- | ---------- | -------------- |
-| xen-bugtool | main | F | 777:1359 | 84 | F |
-| xen-bugtool | load_plugins | F | 1761:1827 | 27 | D |
-| xen-bugtool | collect_data | F | 701:758 | 21 | D |
-| host-installer/install.py | go | F | 89:325 | 60 | F |
-| host-installer/backend.py | performInstallation | F | 293:446 | 31 | E |
-| host-installer/backend.py | partitionTargetDisk | F | 525:587 | 21 | D |
-| host-installer/disktools.py | DOSPartitionTool.writeThisPartitionTable | M | 839:912 | 23 | D |
-| host-installer/restore.py | restoreFromBackup | F | 17:177 | 33 | E |
-| host-installer/product.py | ExistingInstallation._readSettings | M | 101:412 | 75 | F |
-| host-installer/diskutil.py | probeDisk | F | 467:530 | 21 | D |
-| host-installer/init | main | F | 92:247 | 35 | E |
-| host-installer/init | configureNetworking | F | 28:85 | 24 | D |
-| host-installer/tui/repo.py | confirm_load_repo | F | 207:283 | 21 | D |
-| host-installer/tui/network.py | get_iface_configuration | F | 15:134 | 29 | D |
-| host-installer/tui/installer/screens.py | get_name_service_configuration | F | 795:962 | 28 | D |
-| perfmon | main | F | 1307:1522 | 38 | E |
-| perfmon | VMMonitor.get_default_variable_config | M | 858:917 | 23 | D |
-| xcp/cpiofile.py | CpioFile.open | M | 1003:1083 | 22 | D |
-| xcp/bootloader.py | Bootloader.readExtLinux | M | 110:194 | 32 | E |
-| xcp/bootloader.py | Bootloader.readGrub | M | 197:301 | 28 | D |
-| xcp/bootloader.py | Bootloader.readGrub2 | M | 304:463 | 26 | D |
-| xcp/bootloader.py | Bootloader.writeGrub2 | M | 557:619 | 23 | D |
-| xcp/net/ifrename/dynamic.py | DynamicRules.generate | M | 147:227 | 23 | D |
-| xcp/net/ifrename/logic.py | rename_logic | F | 125:366 | 41 | F |
-| xcp/net/ifrename/logic.py | rename | F | 368:498 | 35 | E |
-| xcp/net/ifrename/static.py | StaticRules.load_and_parse | M | 103:210 | 25 | D |
-| xcp/net/ifrename/static.py | StaticRules.generate | M | 212:292 | 23 | D |
-
-#### Verdict
-
-As the five 5 conditions do not change the functionality of the main code paths,
-Python2 compatibility code does not change these complexity numbers.
-
-#### Summary on CC (Cyclomatic Complexity) results
-Only `host-installer/install.py/go()` (CC=60) comes close `bugtool/main()` (CC=84).
-
-The other projects are larger, when summarizing their CC into one number, this
-indicates that other projects need more tests.
 
 #### Conclusion
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,6 +4,13 @@ dictionaryDefinitions: []
 dictionaries:
   - .vscode/ltex.dictionary.en-US.txt
 words:
+  - bugtool
+  - corosync
+  - Initialise
   - ltex
+  - rrdd
+  - xapi
+  - xenserver
+  - xensource
 ignoreWords: []
 import: []

--- a/doc/coverage.md
+++ b/doc/coverage.md
@@ -1,4 +1,4 @@
-## Unit tests with Code coverage with Codecov and Coveralls
+# Unit tests with Code coverage with Codecov and Coveralls
 
 [`pre-commit`](coverage.md) runs `pytest --cov` to collect code coverage
 in its native SQLite database in the file `.coverage` and to generate

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -1,0 +1,124 @@
+# Operation of `xenserver-status-report`
+
+## High-Level Workflow Phases
+
+1. **Discovery**:
+
+   In the discovery phase, `xenserver-status-report` populates:
+
+   1. The global `caps` dictionary with the supported capabilities
+   2. The global `data` dictionary with the supported collection directives.
+
+      For each collection directive, depending on the directive type,
+      the `xenserver-status-report` function `load_plugins()` calls these
+      internal functions to define directives for collecting the requested data
+      for the capability provided by the plugin in the global `data` dictionary
+      of `xenserver-status-report`:
+
+      - `file_output()` to define a directive to collect a file for a capability
+      - `tree_output()` to define a directive to collect a tree for a capability
+      - `func_output()` to define a directive to run an internal function
+      - `cmd_output()` to define a directive to run an external command or a script
+
+      The keys are the filenames of the collected data, and the values are
+      dictionaries with the following keys:
+      - `cap`: The capability of the directive: one of the `CAP_` constants
+      - `path`: If created by `file_output`: The path to the file to collect
+      - `func`: If created by `func_output`: A function that returns the file data
+      - `cmd_args`: If created by `cmd_output`: The command to return the file data
+      - `filter`: An optional filter function to pass the file data through
+
+    The function `load_plugins()` also calls these functions to define the
+     capabilities and collection directives of the external bugtool plugins.
+
+2. **Selection**:
+   Plugins are enabled/disabled based on the `checked` and `hidden` attributes
+   and command line flags as well as `XEN_RT` environment variable.
+
+3. **Collection**:
+   The actions described in the `<collect>` section are performed.
+4. **Archiving**:
+   Collected data is archived in a `tar` or `zip` archive for submission.
+
+## Discovery Phase
+
+During the discovery phase, functions in `xenserver-status-report()`
+collect metadata about the data collection capabilities of xen-bugtool
+and its plugins.
+
+For the plugins, this discovery is done by `load_plugins()`:
+
+```mermaid
+flowchart TD
+  B@{ shape: docs,           label: "Scan the PLUGIN_DIR:
+                                     Get the plugin XML files"}
+  B --> C@{ shape: doc,      label: "For each plugin XML file:
+                                     Read the attributes of the
+                                     <tt>&lt;capability></tt> tag of
+                                     the main plugin XML."}
+  C --> D@{ shape: tag-doc,  label: "Add the capability attrs to the
+                                     list of available capabilities"}
+  D --> E@{ shape: win-pane, label: "Get the <tt>&lt;collect></tt> section
+                                     of each plugin's <tt>stuff.xml</tt>"}
+  E --> F@{ shape: diamond, label: "On each entry of
+                                    <tt>&lt;collect></tt>" }
+  F --> F1["Type &lt;files>:
+           Add pattern to the
+           <tt>data</tt> dictionary"]
+  F --> F2["Type &lt;list>:
+           Add pattern to the
+           <tt>data</tt> dictionary"]
+  F --> F3["Type &lt;directory>:
+            Add directory spec to the
+            <tt>data</tt> dictionary"]
+  F --> F4["Type &lt;command>:
+           Add command to the
+           <tt>data</tt> dictionary"]
+```
+
+## Selection phase
+
+In the selection phase, some or all discovered capabilities are selected
+for collection.
+
+## Collection Phase
+
+In the collection phase, `xenserver-status-report` traverses the internal `data`
+dictionary populated during the discovery phase for selected entries.
+
+It is implemented in the `collect_data()` function and the function it calls.
+
+The sub-phases are:
+
+1. Initialise the output archive.
+2. Run the commands of the selected capabilities and archive their output.
+   - Note: Some commands may create or update files to collect in the next steps
+3. Traverse the `<directory>` entries of the selected capabilities for files.
+4. Archive the files of the selected capabilities.
+
+### Flowchart of the Collection phase
+
+```mermaid
+flowchart TD
+  A1@{        shape: stadium,   label: "Initialise the
+                                        output archive"}
+  A1 --> A2@{ shape: docs,      label: "For all commands of the
+                                        selected capabilities
+                                        in the <tt>data</tt> dictionary"}
+  A2 --> B1@{ shape: processes, label: "Execute commands in parallel"}
+  A2 --> B2@{ shape: processes, label: "Execute commands in parallel"}
+  A2 --> B3@{ shape: processes, label: "Execute commands in parallel"}
+  B1 --> C1@{ shape: bow-rect,  label: "Add output to the archive until finished"}
+  B2 --> C2@{ shape: bow-rect,  label: "Add output to the archive until finished"}
+  B3 --> C3@{ shape: bow-rect,  label: "Add output to the archive until finished"}
+  C1 --> D@{  shape: hourglass, label: "Fork a process for each command to run"}
+  C2 --> D
+  C3 --> D
+  D  --> E["Traverse the
+            <tt>&lt;directory></tt> entries
+            of selected capabilities"]
+  E  --> F@{ shape: bow-rect,   label: "Add the data of the files
+                                        of the selected capabilities
+                                        to the output archive"}
+  F  --> H@{ shape: stadium,    label: "Close the archive"}
+```

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -82,14 +82,17 @@ may occur multiple times):
   - The `label` attribute describes the output. Example:
 
     ```xml
-    <command label="host_data_source_list">/opt/xensource/bin/xe host-data-source-list host=$(/opt/xensource/bin/xe pool-list params=master --minimal)</command>
+    <command label="host_data_source_list">/opt/xensource/bin/xe host-data-source-list
+    host=$(/opt/xensource/bin/xe pool-list params=master --minimal)</command>
     ```
 
 ### Example `stuff.xml` file from the `xapi` bugtool Plugin
 
 ```xml
 <collect>
-<command label="sr_data_source_list">/opt/xensource/bin/xe sr-list --minimal | tr , '\n' | xargs --verbose -n 1 -I {} /opt/xensource/bin/xe sr-data-source-list uuid={} 2>&amp;1</command>
+<command label="sr_data_source_list">/opt/xensource/bin/xe sr-list --minimal |
+   tr , '\n' | xargs --verbose -n 1 -I {} /opt/xensource/bin/xe sr-data-source-list
+   uuid={} 2>&amp;1</command>
 <files>/etc/stunnel/xapi.conf</files>
 <list>/var/lib/corosync</list>
 <list recursive="false">/etc/xen/scripts</list>

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,0 +1,107 @@
+# Plugins for `xen-bugtool` and overall operation
+
+The capabilities of `xen-bugtool` are extended by a number of plugins.
+
+Plugins are defined using XML files that describe what data to collect
+and how to collect it.
+
+This allows for flexible, declarative extension of `xen-bugtool`'s capabilities.
+
+## Top-level Plugin XML Structure
+
+Plugins are loaded by the `load_plugins()` function of `xenserver-status-report`.
+It looks in `PLUGIN_DIR` (`/etc/xensource/bugtool`) for XML files.
+
+For example, the `xapi` plugin is defined in `/etc/xensource/bugtool/xapi.xml`.
+
+Each plugin XML file uses a `<capability>` root element with several attributes:
+
+- **`pii`**: If the collected data may contain Personally Identifiable Information.
+  - Values: `no`, `yes`, `maybe`, or `if_customized`.
+- **`min_size` / `max_size`**:
+  - Values: Minimum and maximum expected size (in bytes) of the collected data.
+- **`min_time` / `max_time`**:
+  - Values: Minimum and maximum expected time (in seconds) to collect the data.
+- **`mime`**: The type of data collected.
+  - Values: `application/data` or `text/plain` (default).
+  - Included in the output of `--capabilities` as the `content-type` attribute
+    of the capability. No other use: Not included in the status-report itself.
+  - Currently, all currently known plugins use the default of `text/plain`.
+- **`checked`**: Whether this plugin is enabled by default.
+  - Values: `true` or `false`.
+- **`hidden`**: Whether this plugin is hidden from the user interface.
+  - Values: `true` or `false`.
+
+### Example `<capability>` Definition
+
+```xml
+<capability pii="yes" max_size="16384" max_time="4" checked="true"/>
+```
+
+Best practices:
+
+- Set `pii` to indicate if Personally Identifiable Information may be collected.
+- Set `max_size` and `max_time` according to the expected maximum size and time
+
+## Defining Data Collection in `/etc/xensource/bugtool/<plugin>/stuff.xml`
+
+The data collection directives are specified in another XML file.
+
+It is found in a subdirectory named after the plugin,
+e.g., `/etc/xensource/bugtool/xapi/stuff.xml`.
+
+It contains a single `<collect>` section which defines what data to gather.
+The possible subsections of the `<collect>` section are (each of these
+may occur multiple times):
+
+- **`<files>`**:
+  - Collect a file path, optionally using wildcards. Example:
+
+    ```xml
+    <files>/sys/fs/gfs2/*/uuid</files>
+    ```
+
+- **`<list recursive="true|false">`**:
+  - List the contents of specified directories.
+    If `recursive` is `true`, subdirectories are included. Example:
+
+    ```xml
+    <list>/var/lib/corosync</list>
+    ```
+
+- **`<directory pattern="regex" negate="true|false">basepath</directory>`**:
+  - Collect files in `basepath` matching the given `regex` pattern.
+    (Or not matching the pattern when `negate="true"`).
+    Example:
+
+    ```xml
+    <directory pattern=".*xcp-rrdd-plugins\.log.*">/var/log</directory>
+    ```
+
+- **`<command label="...">`**: Run the specified command and collect its output.
+  - The `label` attribute describes the output. Example:
+
+    ```xml
+    <command label="host_data_source_list">/opt/xensource/bin/xe host-data-source-list host=$(/opt/xensource/bin/xe pool-list params=master --minimal)</command>
+    ```
+
+### Example `stuff.xml` file from the `xapi` bugtool Plugin
+
+```xml
+<collect>
+<command label="sr_data_source_list">/opt/xensource/bin/xe sr-list --minimal | tr , '\n' | xargs --verbose -n 1 -I {} /opt/xensource/bin/xe sr-data-source-list uuid={} 2>&amp;1</command>
+<files>/etc/stunnel/xapi.conf</files>
+<list>/var/lib/corosync</list>
+<list recursive="false">/etc/xen/scripts</list>
+<directory pattern=".*\.log$" negate="false">/var/log/xen</directory>
+</collect>
+```
+
+In this example, `2>&amp;1` is the XML-escaped form of the shell redirection `2>&1`,
+which redirects `stderr` (file descriptor 2) to `stdout` (file descriptor 1).
+
+### Best Practices for plugin development
+
+- Use `pattern` and `negate` to fine-tune file selection.
+- Provide meaningful `label` values for commands.
+- Test plugins and ensure they perform within defined time and size limits.

--- a/doc/pre-commit.md
+++ b/doc/pre-commit.md
@@ -1,3 +1,5 @@
+# Running checks using pre-commit
+
 ## Running CI checks locally (and in GitHub CI) using `pre-commit`
 
 This project uses `pre-commit` to run the tests in a defined, clean environment:
@@ -6,10 +8,14 @@ This project uses `pre-commit` to run the tests in a defined, clean environment:
 - It runs `pytest` with coverage and checks the coverage on the changed lines
 - It runs `pylint`, `mypy`, `pyright` and `pytype`:
 
+The pre-commit configuration defines how it runs
+`pytest`, `pylint` and static analysis using `mypy`, `pyright`, and `pytype`.
+
 Links:
-- https://mypy.readthedocs.io/en/stable/
-- https://microsoft.github.io/pyright/
-- https://google.github.io/pytype/user_guide.html
+
+- <https://mypy.readthedocs.io/en/stable/>
+- <https://microsoft.github.io/pyright/>
+- <https://google.github.io/pytype/user_guide.html>
 
 - Because this project is now using Python3.6+, type annotations (PEP 484)
   no longer need to be in comments, but can be in the code directly.
@@ -27,17 +33,19 @@ uv pip install pre-commit
 . .venv/bin/activate  # (if using a virtualenv)
 pre-commit run -av
 ```
+
 Without -a, it would only run hooks for staged files with changes.
 With `-a`, `pre-commit run -a` runs all fixes and checks.
 
 You can skip checks if you commit by passing `SKIP=` in the environment:
+
 ```py
 export SKIP=mypy,pylint;git commit -m "quick save"  # (or for --amend)
 ```
 
 Only the 1st invocation of pre-commit will be slow as it creates `virtualenv`s
 for each sub-hook configured in its configuration file
-[.pre-commit-config.yaml](.pre-commit-config.yaml). Subsequent runs are fast.
+[`.pre-commit-config.yaml`](.pre-commit-config.yaml). Subsequent runs are fast.
 
 If a formatting hook like trailing-whitespace fails, just run `git add -p` to
 stage the whitespace fixes into the index and run pre-commit again.
@@ -47,9 +55,12 @@ When you are ready to use pre-commit as a pre-commit hook in this clone,
 run this command to install it. Until uninstalled from this repo, it will
 then run on each commit. This is completely optional and just a matter of
 preference:
+
 ```bash
 pre-commit install
 ```
+
+## Videos about pre-commit
 
 ### The easy way to keep your repos tidy (5 minutes)
 [![The easy way to keep your repos tidy.](https://img.youtube.com/vi/psjz6rwzMdk/0.jpg)](https://www.youtube.com/watch?v=psjz6rwzMdk)
@@ -83,17 +94,19 @@ new commit in the stack work for itself, you can use a git alias:
 [alias]
     prebase = rebase -x 'pre-commit run --from-ref HEAD~ --to-ref HEAD'
 ```
+
 When using `git prebase -i` instead of `git rebase -i`, pre-commit will
 run the configured commit hooks for each commit of the rebase.
 
 This ensures that tests also pass on each intermediate commit.
 
 When, during a `git prebase -i`, a pre-commit hook fails or makes changes,
-the `rebase` stops, this is the workflow:
-- You'll see the reason of the error and get a shell.
-- You can then can check `git diff`, in case formatters fixed up the code.
-- You can then fix any errors and stage them
-- Then, run `git rebase --continue` to continue the rebase to the next step.
+the `rebase` stops. These are the steps to fix such failed rebase:
 
-A very helpful explanation by the Author of a book on git is here:
-https://adamj.eu/tech/2022/11/07/pre-commit-run-hooks-rebase/
+- Review which errors were raised by the `pre-commit` hooks.
+- In case formatters fixed the causes already, check `git diff`.
+- Fix the errors and stage the fixes using `git add <file>`.
+- Run `git rebase --continue` to try to continue the rebase to the next step.
+
+A very helpful explanation by the author of a book on git is here:
+<https://adamj.eu/tech/2022/11/07/pre-commit-run-hooks-rebase/>

--- a/doc/release.md
+++ b/doc/release.md
@@ -5,6 +5,7 @@ This is the process of manually tagging a new version that was merged to master.
 There are bump tools which help to automate this process, but they are not added yet.
 
 First switch to the master branch and pull the latest merge.
+
 ```bash
 $ git switch master
 $ git pull origin
@@ -18,20 +19,26 @@ Date:   Thu Feb 22 15:49:23 2024 +0100
 
     CA-389135: Fix the off-by-default and hidden direct-fetched VM RRDs
 ```
+
 Ensure that your commit hash is identical with the latest commit on master
 shown in the GitHub web repository.
 
 Get the latest tag:
+
 ```bash
 $ git tag | sort -n | tail -n1
 v2.0.1
 ```
+
 Tag a new version using an annotated tag (one which is recorded like a git commit):
+
 ```bash
 $ git_tag=v2.0.2
 $ git tag -m "Tag $git_tag" $git_tag
 ```
+
 Confirm that the tag was created on the correct commit:
+
 ```bash
 $ git show $git_tag|head -15
 tag v2.0.2
@@ -50,18 +57,19 @@ Date:   Thu Feb 22 15:49:23 2024 +0100
     CA-389135: Fix the off-by-default and hidden direct-fetched VM RRDs
 $ git push --tags
 ```
-Then wait for some time for the new update to be synced to the mirror repo.
 
+Then wait for some time for the new update to be synced to the mirror repo.
 
 ## Creating a new release
 
 After tagging a new version, it would also be good for review to create
 a new release:
-- With it, you can generate and edit the release notes based on the commits
-in it.
+
+- With it, you can generate and edit the release notes based on the commits in it.
 - Reviewers can get a better picture of the changes in the release using the release notes.
 
-Navigate to https://github.com/xenserver/status-report/tags:
+Navigate to <https://github.com/xenserver/status-report/tags>:
+
 - Visit the new tag:
   https://github.com/xenserver/status-report/releases/tag/v2.0.2
 - Click the button “Create release from tag”

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -5,19 +5,21 @@ Unit tests, Integration tests, End-to-End tests.
 
 This section provides a definition of the terms, how they relate and policies.
 
-### The testing pyramid, which is widely used in the testing space:
+## The testing pyramid
 
-  [![The testing pyramid - Intro](https://upload.wikimedia.org/wikipedia/commons/a/a4/Testing_Pyramid.png)](https://en.wikipedia.org/wiki/Test_automation)
+[![The testing pyramid - Intro](https://upload.wikimedia.org/wikipedia/commons/a/a4/Testing_Pyramid.png)](https://en.wikipedia.org/wiki/Test_automation)
 
-  [![The Testing Pyramid: How to Structure Your Test Suite](https://semaphoreci.com/wp-content/uploads/2022/03/pyramid-progression.webp)](https://semaphoreci.com/blog/testing-pyramid)
-  References:
-  - https://semaphoreci.com/blog/testing-pyramid
-  - https://web.dev/articles/ta-strategies
-  - https://semaphoreci.com/wp-content/uploads/2022/03/pyramid-progression.webp
+[![The Testing Pyramid: How to Structure Your Test Suite](https://semaphoreci.com/wp-content/uploads/2022/03/pyramid-progression.webp)](https://semaphoreci.com/blog/testing-pyramid)
+References:
 
-### Unit tests
+- <https://semaphoreci.com/blog/testing-pyramid>
+- <https://web.dev/articles/ta-strategies>
+- <https://semaphoreci.com/wp-content/uploads/2022/03/pyramid-progression.webp>
+
+## Unit tests
 
 The bulk of tests should be unit tests:
+
 - Tests one unit of execution (one function, class, or even method of a class)
 - Very easy to write and update (even AI can be used to generate ideas for them)
 - Fast to execute (few milliseconds per unit test)
@@ -26,17 +28,16 @@ The bulk of tests should be unit tests:
   because Mocks are lies to tell “all is fine” and thus may only be used outside
   the test target (function, class, or method).
 
-### Integration tests
+## Integration tests
 
 - These test the correct integration of a number of functional units
   (functions, classes, methods)
 - Still easy to write and update
-- Still very fast vast to execute (few milliseconds per unit test)
+- Still very fast to execute (few milliseconds per unit test)
 
-### End-to-End Tests
+## End-to-End Tests
 
 - These test an entire program end-to-end.
-- All tests in XenRT are E2E tests, but XenRT tests are even system tests.
 - Any test that runs a program as a whole to test its functionality is an E2E test.
   - Using a sufficient test environment, many E2E tests are possible without XenRT.
 - The final E2E test for `xenserver-status-report` is to get a bug-report through

--- a/tests/unit/conftest-README.md
+++ b/tests/unit/conftest-README.md
@@ -1,11 +1,19 @@
-# tests/unit/conftest-README:
+# Documentation of `tests/unit/conftest.py`
 
-This [README](../../README.md) documents the
-[pytest](https://docs.pytest.org/en/4.6.x/contents.html)
-[`conftest.py`](https://docs.pytest.org/en/4.6.x/pythonpath.html?highlight=conftest.py#test-modules-conftest-py-files-inside-packages)
-file [`tests/unit/conftest.py`](conftest.py).
+## Overview
+
+`conftest.py` is a special file used by the `pytest` framework.
+It is a local plugin for your tests, where you can define fixtures, hooks,
+and other configuration for your tests.
+
+`pytest` automatically discovers `conftest.py`, and makes
+the fixtures in it available to all tests in its directory.
+
+This is described in the `pytest` documentation:
+<https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files>
 
 The tests in [`tests/unit/`](.) use it for three classes of tests:
+
 - [Unit-testing](https://en.wikipedia.org/wiki/Unit_testing) of single functions
 - [Functional testing](https://en.wikipedia.org/wiki/Functional_testing)
   of a chain of functions, testing their in- and output
@@ -13,28 +21,16 @@ The tests in [`tests/unit/`](.) use it for three classes of tests:
   of `xen-bugtool` the main code of [`xen-bugtool`](../../xen-bugtool)
   - by calling its function `main()` in [`tests/unit/test_main.py`](test_main.py)
 
-It contains several [pytest](https://docs.pytest.org/en/4.6.x/contents.html)
-fixtures which are described below.
-
-
-## Overview
-
-`conftest.py` is a special file used by the pytest framework.
-It is a local plugin for your tests, where you can define fixtures, hooks,
-and other configuration for your tests.
-
-`pytest` automatically discovers `conftest.py`, and makes
-the fixtures in it available to all tests in its directory.
-
-## Fixtures
+## Fixtures provided by `tests/unit/conftest.py`
 
 Fixtures are functions that set up and tear down test environments.
 They are decorated with `@pytest.fixture`.
 Fixtures defined in `conftest.py` are available to all test files
 in the same directory and subdirectories.
 
-Links to the [pytest](https://docs.pytest.org/en/8.0.x/how-to/index.html#how-to)
+Links to the [`pytest`](https://docs.pytest.org/en/8.0.x/how-to/index.html#how-to)
 documentation pages about fixtures:
+
 - [An introduction to fixtures](https://docs.pytest.org/en/8.0.x/fixture.html):
   Quick intro into the topic of fixtures
 - [How to use fixtures](https://docs.pytest.org/en/8.0.x/how-to/fixtures.html):
@@ -44,6 +40,7 @@ documentation pages about fixtures:
 
 These are the fixtures defined in [`tests/unit/conftest.py`](conftest.py),
 their name and purpose is:
+
 - `builtins`: Provide the name of the built-in module for Python 2.x and Python 3.x
 - `testdir`: Provide the directory of the unit test for locating files relative to it.
 - `dom0_template`: Provide the directory of the dom0 template.
@@ -62,10 +59,12 @@ their name and purpose is:
 ## Fixtures
 
 ### `builtins`
-- **Purpose**: Provide the `builtins` module for __Python 2.x__ *and*
-  __Python 3.x__
+
+- **Purpose**: Provide the `builtins` module for *Python 2.x* and
+  *Python 3.x*
 
 - **Example**:
+
     ```python
     def test_example(builtins, mocker):
         # `builtins` provides the builtins module for Python 2 and Python 3:
@@ -73,18 +72,22 @@ their name and purpose is:
     ```
 
 ### `testdir`
+
 - **Purpose**: Provide the directory of the main [tests/](..) directory
 - **Example**:
+
     ```python
     @pytest.fixture
     def dom0_template(testdir):
         # relative to testdir, provide the dom0-template directory
-        return  testdir + "/../integration/dom0-template
-        ```
+        return testdir + "/../integration/dom0-template"
+    ```
 
 ### `dom0_template`
+
 - **Purpose**: Provide the directory of the dom0 template directory
 - **Example**:
+
     ```python
     def test_example(bugtool, dom0_template):
         # Provide fixtures and test cases with access to example files.
@@ -94,11 +97,13 @@ their name and purpose is:
     ```
 
 ### `imported_bugtool`
+
 - **Purpose**: Import the `xen-bugtool` script as a module for
                executing unit tests on functions.
-- **Scope**: The entire pytest session, it only runs once.
+- **Scope**: The entire `pytest` session, it only runs once.
 - **Use case**: Only for other fixtures that prepare it for tests.
 - **Example use**:
+
     ```python
     @pytest.fixture(scope="function")
     def bugtool(imported_bugtool):
@@ -113,8 +118,10 @@ their name and purpose is:
     ```
 
 ### `bugtool`
-- **Purpose**: Initialize the bugtool data dict for each test.
+
+- **Purpose**: Initialize the data dictionary for each test.
 - **Example**:
+
     ```python
     def test_example(bugtool):
         # Test specific functionalities of the bugtool using initialized data
@@ -122,10 +129,11 @@ their name and purpose is:
     ```
 
 ### `in_tmpdir`
+
 - **Purposes**:
-    - Provide a pytest
-    [`tmpdir`](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmpdir-fixture)
-      fixture.
+
+  - Provide the [`tmpdir`](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmpdir-fixture)
+    fixture.
     - `cd` into it before yielding control switch back afterwards.
     - Offer the [`py.path.local`](https://py.readthedocs.io/en/latest/path.htm)
       object which provides
@@ -133,13 +141,15 @@ their name and purpose is:
       - See the **Example 2** below on how to use it.
 
 - **Examples**:
+
     ```python
     # Example 1: Test requests the fixture using a decorator:
     @pytest.usefixtures("in_tmpdir")
     def test_runs_in_tmpdir(bugtool):
         assert bugtool.function_creating_files_in_the_cwd()
-        # restore & cleanup is taken care of by the fixures.
+        # restore & cleanup is taken care of by the fixtures.
     ```
+
     ```python
     # Example 2: Get fixture as argument of type py.path.local:
     def test_prepares_tmpdir_for_testing(in_tmpdir, bugtool):
@@ -150,10 +160,12 @@ their name and purpose is:
     ```
 
 ### `bugtool_log`
+
 - **Purpose**: Like `in_tmpdir` and provide the bugtool fixture.
 
   It adds checking the file located at `bugtool.XEN_BUGTOOL_LOG` for output.
 - **Example**:
+
     ```python
     def test_not_generating_unexpected_logs(bugtool_log):
         # This fixture fails this test and shows "message"
@@ -162,20 +174,21 @@ their name and purpose is:
     ```
 
 ### `isolated_bugtool`
-- **Purpose**: Like `bugtool_log` and make the working
- directory read-only.
+
+- **Purpose**: Like `bugtool_log` and make the working directory read-only.
 - **Example**:
+
     ```python
     def test_cannot_write_to_its_current_directory(isolated_bugtool):
         # The code under test can't write its working directory:
         open("file", "w")  # will raise an Exception
     ```
 
-
 ## Further Reading
 
-Links to the [pytest](https://docs.pytest.org/en/8.0.x/how-to/index.html#how-to)
-documentation pages about fixtures:
+Links to the [documentation](https://docs.pytest.org/en/8.0.x/how-to/index.html#how-to)
+pages about fixtures:
+
 - [An introduction to fixtures](https://docs.pytest.org/en/8.0.x/fixture.html):
   Quick intro into the topic of fixtures
 - [How to use fixtures](https://docs.pytest.org/en/8.0.x/how-to/fixtures.html):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -176,3 +176,22 @@ def isolated_bugtool(bugtool_log):
     os.chmod(".", 0o777)  # nosec # restore write permissions (for cleanup)
 
     # upon return, bugtool_log continues with its cleanup
+
+
+@pytest.fixture(scope="function")
+def bugtool_fixture(isolated_bugtool):
+    """
+    Fixture that wraps isolated_bugtool and restores its state after each test.
+    """
+
+    # Assert that isolated_bugtool is pristine and we have a clean state to start:
+    assert isolated_bugtool.data == {}
+    assert isolated_bugtool.entries is None
+
+    yield isolated_bugtool  # runs the test case in the read-only directory
+
+    # Restore isolated_bugtool to its pristine state:
+    isolated_bugtool.data = {}
+    isolated_bugtool.entries = None
+
+    # upon return, isolated_bugtool continues with its cleanup

--- a/tests/unit/test_cmd_output.py
+++ b/tests/unit/test_cmd_output.py
@@ -1,0 +1,110 @@
+"""tests/unit/test_cmd_output.py: Unit-Test bugtool.cmd_output()"""
+
+
+def test_cmd_output_mismatching_cap(bugtool_fixture):
+    """Assert that mismatching cap causes no extension of bugtool.data:"""
+
+    # Prepare that mismatching cap causes no output in bugtool.data:
+    bugtool_fixture.entries = [bugtool_fixture.CAP_PAM]
+
+    # Act
+    bugtool_fixture.cmd_output(bugtool_fixture.CAP_XENSERVER_LOGS, ["/bin/sh"])
+
+    # Assert that the command is not added to data
+    assert bugtool_fixture.data == {}
+
+
+def check_cmd_output_data(bugtool, command, label=None, filter_func=None):
+    """
+    Assert that cmd_output() stores the expected command in bugtool.data
+    It works by setting bugtool.data and bugtool.entries to fixed values
+    and asserting the expected bugtool.data after the check.
+
+    Use this function only with bugtool_fixture which saves and restores
+    the original values of these variables to avoid affecting other test cases.
+    """
+
+    # Prepare
+    bugtool.entries = [bugtool.CAP_PAM]
+    bugtool.data = {}
+
+    # Act
+    bugtool.cmd_output(bugtool.entries[0], command, label, filter=filter_func)
+
+    # Assert
+    assert bugtool.data == {
+        label
+        or command: {
+            "filter": filter_func,
+            "cap": bugtool.entries[0],
+            "cmd_args": command,
+        }
+    }
+
+
+def test_cmd_output_command(bugtool_fixture):
+    """Test how cmd_output() handles a command which can be found"""
+
+    check_cmd_output_data(bugtool_fixture, "pwd --version")
+
+
+def test_cmd_output_command_label(bugtool_fixture):
+    """Test how cmd_output() handles a command which can be found with a label"""
+
+    check_cmd_output_data(bugtool_fixture, "pwd --version", "label")
+
+
+def test_cmd_output_missing_command(bugtool_fixture):
+    """Test how cmd_output() handles a missing command"""
+
+    check_cmd_output_data(bugtool_fixture, "/missing-cmd arg")
+
+
+def test_cmd_output_missing_command_with_label(bugtool_fixture):
+    """Test how cmd_output() handles a missing command with a label"""
+
+    check_cmd_output_data(bugtool_fixture, "/missing-cmd arg", "label")
+
+
+def test_cmd_output_multiple_calls(bugtool_fixture):
+    """Assert the cumulative effect of multiple cmd_output() calls."""
+
+    # Prepare
+    #
+    cap1 = bugtool_fixture.CAP_OEM
+    cap2 = bugtool_fixture.CAP_PAM
+    bugtool_fixture.entries = [cap1, cap2]
+
+    def mock_filter():
+        """No-op mock filter used in tests for asserting it in bugtool_fixture.data"""
+
+    # Act
+    #
+    cmd1 = ["/usr/bin/pwd", "--version"]
+    cmd2 = ["/missing-cmd", "arg1", "arg2"]
+    bugtool_fixture.cmd_output("not_an_activated_capability", cmd1)
+    bugtool_fixture.cmd_output(cap1, [cmd1[0]], filter=mock_filter)
+    bugtool_fixture.cmd_output(cap1, cmd1)
+    bugtool_fixture.cmd_output(cap2, cmd2)
+
+    # Assert
+    #
+    assert bugtool_fixture.data == {
+        "pwd": {
+            "cap": cap1,
+            "cmd_args": ["/usr/bin/pwd"],
+            "filter": mock_filter,
+        },
+        # At the moment, we also add commands which are missing on the system to data
+        "missing-cmd arg1 arg2": {
+            "cap": cap2,
+            "cmd_args": cmd2,
+            "filter": None,
+        },
+        # Uses command as string without path as key when no label is set
+        "pwd --version": {
+            "cap": cap1,
+            "cmd_args": cmd1,
+            "filter": None,
+        },
+    }


### PR DESCRIPTION
AI review PR

## Summary by Sourcery

Add unit tests for bugtool.cmd_output() behavior and introduce a reusable fixture for running tests in an isolated bugtool environment.

Enhancements:
- Introduce a bugtool_fixture pytest fixture that wraps isolated_bugtool and restores its state after each test.

Tests:
- Add tests verifying cmd_output() ignores mismatching capabilities and does not modify bugtool.data.
- Add tests covering command and label handling, including filters and multiple commands, ensuring bugtool.data is populated as expected.